### PR TITLE
Make the link type customizable (Issue #7).

### DIFF
--- a/dashboard.org
+++ b/dashboard.org
@@ -1,10 +1,10 @@
 
-* Mu for Emacs (mu4e)                                        *[[mu4e:flag:unread|%3d Unread][ 17 Unread]]*
+* Mu for Emacs (mu4e)                                        *[[mu:flag:unread|%3d Unread][ 17 Unread]]*
 
-[[mu4e:flag:unread][Unread]] /[[mu4e:flag:unread|(%3d)][( 17)]]/ .... [u]  [[mu4e:date:today..now][Today]] /[[mu4e:date:today..now|(%3d)][(113)]]/ .......... [t]  *Compose* ...... [C]
-[[mu4e:m:/inria/inbox or m:/gmail/inbox or m:/univ/inbox][Inbox]]  /[[mu4e:m:/inria/inbox or m:/gmail/inbox or m:/univ/inbox|(%3d)][( 33)]]/ .... [i]  [[mu4e:date:2d..today and not date:today..now][Yesterday]] /[[mu4e:date:2d..today and not date:today..now|(%3d)][(242)]]/ ...... [y]  *Update* ....... [U]
-[[mu4e:m:/inria/drafts or m:/gmail/drafts or m:/univ/drafts][Drafts]] /[[mu4e:m:/inria/drafts or m:/gmail/drafts or m:/univ/drafts|(%3d)][(  2)]]/ .... [d]  [[mu4e:date:7d..now][Last week]] /[[mu4e:date:7d..now|(%4d)][( 989)]]/ ..... [w]  *Switch context* [;]
-[[mu4e:m:/inria/sent or m:/gmail/sent or m:/univ/sent][Sent]] /[[mu4e:m:/inria/sent or m:/gmail/sent or m:/univ/sent|(%5d)][( 7082)]]/ .... [s]  [[mu4e:date:4w..now][Last month]] /[[mu4e:date:4w..|(%4d)][(3606)]]/ .... [m]  *Quit* ......... [q]
+[[mu:flag:unread][Unread]] /[[mu:flag:unread|(%3d)][( 17)]]/ .... [u]  [[mu:date:today..now][Today]] /[[mu:date:today..now|(%3d)][(113)]]/ .......... [t]  *Compose* ...... [C]
+[[mu:m:/inria/inbox or m:/gmail/inbox or m:/univ/inbox][Inbox]]  /[[mu:m:/inria/inbox or m:/gmail/inbox or m:/univ/inbox|(%3d)][( 33)]]/ .... [i]  [[mu:date:2d..today and not date:today..now][Yesterday]] /[[mu:date:2d..today and not date:today..now|(%3d)][(242)]]/ ...... [y]  *Update* ....... [U]
+[[mu:m:/inria/drafts or m:/gmail/drafts or m:/univ/drafts][Drafts]] /[[mu:m:/inria/drafts or m:/gmail/drafts or m:/univ/drafts|(%3d)][(  2)]]/ .... [d]  [[mu:date:7d..now][Last week]] /[[mu:date:7d..now|(%4d)][( 989)]]/ ..... [w]  *Switch context* [;]
+[[mu:m:/inria/sent or m:/gmail/sent or m:/univ/sent][Sent]] /[[mu:m:/inria/sent or m:/gmail/sent or m:/univ/sent|(%5d)][( 7082)]]/ .... [s]  [[mu:date:4w..now][Last month]] /[[mu:date:4w..|(%4d)][(3606)]]/ .... [m]  *Quit* ......... [q]
 
 * Queries
 
@@ -16,23 +16,23 @@ Type *C-c C-c* on the /CALL/ line below to evaluate your query.
 
 * Saved searches
 
-[[mu4e:m:/inria/archive or m:/gmail/archive or m:/univ/archive][Archive]] /[[mu4e:m:/inria/archive or m:/gmail/archive or m:/univ/archive|(%6d)][( 44132)]]/ ...... [[mu4e:m:/inria/archive or m:/gmail/archive or m:/univ/archive||100][100]] - [[mu4e:m:/inria/archive or m:/gmail/archive or m:/univ/archive||500][500]]  [[mu4e:flag:attach][ Attachments]] /[[mu4e:flag:attach|(%5d)][( 9954)]]/ ... [[mu4e:flag:attach||99999][all]] - [[mu4e:size:10M..][big]]
-[[mu4e:flag:flagged][Important]] /[[mu4e:flag:flagged|(%4d)][( 278)]]/ ...... [[mu4e:flag:flagged||100][100]] - [[mu4e:flag:flagged||500][500]]   [[mu4e:flag:encrypted][Encrypted]] /[[mu4e:flag:encrypted|(%4d)][( 888)]]/ ...... [[mu4e:flag:encrypted||100][100]] - [[mu4e:flag:encrypted||500][500]]
+[[mu:m:/inria/archive or m:/gmail/archive or m:/univ/archive][Archive]] /[[mu:m:/inria/archive or m:/gmail/archive or m:/univ/archive|(%6d)][( 44132)]]/ ...... [[mu:m:/inria/archive or m:/gmail/archive or m:/univ/archive||100][100]] - [[mu:m:/inria/archive or m:/gmail/archive or m:/univ/archive||500][500]]  [[mu:flag:attach][ Attachments]] /[[mu:flag:attach|(%5d)][( 9954)]]/ ... [[mu:flag:attach||99999][all]] - [[mu:size:10M..][big]]
+[[mu:flag:flagged][Important]] /[[mu:flag:flagged|(%4d)][( 278)]]/ ...... [[mu:flag:flagged||100][100]] - [[mu:flag:flagged||500][500]]   [[mu:flag:encrypted][Encrypted]] /[[mu:flag:encrypted|(%4d)][( 888)]]/ ...... [[mu:flag:encrypted||100][100]] - [[mu:flag:encrypted||500][500]]
 
 ** People 
 
-[[mu4e:from:rms@gnu.org][Richard Stallman]] /[[mu4e:from:rms@gnu.org|(%3d)][(508)]]/ ............................ [[mu4e:mu4e:from:rms@gnu.org||100][100]] - [[mu4e:from:rms@gnu.org||500][500]] - [[mu4e:from:rms@gnu.org||9999][all]]
-[[mu4e:from:djcb@djcbsoftware.nl][Dirk-Jan C. Binnema]] /[[mu4e:from:djcb@djcbsoftware.nl|(%2d)][(50)]]/ .......................... [[mu4e:from:djcb@djcbsoftware.nl||100][100]] - [[mu4e:from:djcb@djcbsoftware.nl||500][500]] - [[mu4e:from:djcb@djcbsoftware.nl||9999][all]]
+[[mu:from:rms@gnu.org][Richard Stallman]] /[[mu:from:rms@gnu.org|(%3d)][(508)]]/ ............................ [[mu:mu:from:rms@gnu.org||100][100]] - [[mu:from:rms@gnu.org||500][500]] - [[mu:from:rms@gnu.org||9999][all]]
+[[mu:from:djcb@djcbsoftware.nl][Dirk-Jan C. Binnema]] /[[mu:from:djcb@djcbsoftware.nl|(%2d)][(50)]]/ .......................... [[mu:from:djcb@djcbsoftware.nl||100][100]] - [[mu:from:djcb@djcbsoftware.nl||500][500]] - [[mu:from:djcb@djcbsoftware.nl||9999][all]]
 
 ** Date
 
-[[mu4e:date:20200101..20201231][Year 2020]] /[[mu4e:date:20200101..20201231|(%5d)][(28340)]]/ [[mu4e:date:20190101..20191231][       Year 2019]] /[[mu4e:date:20190101..20191231|(%5d)][(19845)]]/ [[mu4e:date:20180101..20181231][       Year 2018]] /[[mu4e:date:20180101..20181231|(%5d)][( 3038)]]/
+[[mu:date:20200101..20201231][Year 2020]] /[[mu:date:20200101..20201231|(%5d)][(28340)]]/ [[mu:date:20190101..20191231][       Year 2019]] /[[mu:date:20190101..20191231|(%5d)][(19845)]]/ [[mu:date:20180101..20181231][       Year 2018]] /[[mu:date:20180101..20181231|(%5d)][( 3038)]]/
 
 ** Mailing lists
 
-[[mu4e:list:emacs-devel.gnu.org
-][Emacs development]] /[[mu4e:list:emacs-devel.gnu.org|(%4d)][(3208)]]/ .......................... [[mu4e:list:emacs-devel.gnu.org||100][100]] - [[mu4e:list:emacs-devel.gnu.org||500][500]] - [[mu4e:list:emacs-devel.gnu.org||9999][all]]
-[[mu4e:list:mu-discuss.googlegroups.com][Mu4e discussions]] /[[mu4e:list:mu-discuss.googlegroups.com|(%4d)][( 267)]]/ ........................... [[mu4e:list:mu-discuss.googlegroups.com||100][100]] - [[mu4e:list:mu-discuss.googlegroups.com||500][500]] - [[mu4e:list:mu-discuss.googlegroups.com||9999][all]]
+[[mu:list:emacs-devel.gnu.org
+][Emacs development]] /[[mu:list:emacs-devel.gnu.org|(%4d)][(3208)]]/ .......................... [[mu:list:emacs-devel.gnu.org||100][100]] - [[mu:list:emacs-devel.gnu.org||500][500]] - [[mu:list:emacs-devel.gnu.org||9999][all]]
+[[mu:list:mu-discuss.googlegroups.com][Mu4e discussions]] /[[mu:list:mu-discuss.googlegroups.com|(%4d)][( 267)]]/ ........................... [[mu:list:mu-discuss.googlegroups.com||100][100]] - [[mu:list:mu-discuss.googlegroups.com||500][500]] - [[mu:list:mu-discuss.googlegroups.com||9999][all]]
 
 * Information
 

--- a/mu4e-dashboard.el
+++ b/mu4e-dashboard.el
@@ -42,7 +42,17 @@
 (defvar mu4e-dashboard--buffer nil)
 
 ;; Install the mu4e link type
-(org-add-link-type "mu4e" 'mu4e-dashboard-follow-mu4e-link)
+(defgroup mu4e-dashboard nil
+  "Provides a new Org mode link type for mu4e queries."
+  :group 'comm)
+
+(defcustom mu4e-dashboard-link-name "mu"
+  "Default link name."
+  :type 'string)
+
+(org-link-set-parameters
+ mu4e-dashboard-link-name
+ :follow #'mu4e-dashboard-follow-mu4e-link)
 
 ;; Minor mode to simulate buffer local keybindings.
 ;;;###autoload
@@ -147,7 +157,7 @@ have the same size as the current description."
   (let ((buffer (current-buffer)))
     (org-element-map (org-element-parse-buffer) 'link
       (lambda (link)
-        (when (string= (org-element-property :type link) "mu4e")
+        (when (string= (org-element-property :type link) mu4e-dashboard-link-name)
           (let* ((path  (org-element-property :path link))
                  (query (string-trim (nth 0 (split-string path "|"))))
                  (fmt   (nth 1 (split-string path "|")))
@@ -182,7 +192,7 @@ have the same size as the current description."
   (mu4e-dashboard-clear-all)
   (org-element-map (org-element-parse-buffer) 'link
     (lambda (link)
-      (when (string= (org-element-property :type link) "mu4e")
+      (when (string= (org-element-property :type link) mu4e-dashboard-link-name)
         (mu4e-dashboard-update-link link)
         (redisplay t)))))
 
@@ -223,7 +233,7 @@ have the same size as the current description."
   
   (org-element-map (org-element-parse-buffer) 'link
     (lambda (link)
-      (when (string= (org-element-property :type link) "mu4e")
+      (when (string= (org-element-property :type link) mu4e-dashboard-link-name)
         (mu4e-dashboard-clear-link link))))
   (redisplay t))
 

--- a/side-dashboard.org
+++ b/side-dashboard.org
@@ -1,43 +1,43 @@
 
-* Mailboxes                 *[[mu4e:flag:unread|%2d][ 4]]*
+* Mailboxes                 *[[mu:flag:unread|%2d][ 4]]*
 
-/[i]/ [[mu4e:m:/inria/inbox or m:/gmail/inbox or m:/univ/inbox][Inbox]] /.............../ /[[mu4e:m:/inria/inbox or m:/gmail/inbox or m:/univ/inbox|%2d][ 4]]/
-/[f]/ [[mu4e:flag:flagged][Important]] /........../ /[[mu4e:flag:flagged|%3d][281]]/
-/[d]/ [[mu4e:m:/inria/drafts or m:/gmail/drafts or m:/univ/drafts][Drafts]] /.............../ /[[mu4e:m:/inria/drafts or m:/gmail/drafts or m:/univ/drafts|%1d][1]]/
-/[s]/ [[mu4e:m:/inria/sent or m:/gmail/sent or m:/univ/sent][Sent]] /............../ /[[mu4e:m:/inria/sent or m:/gmail/sent or m:/univ/sent|%4d][7186]]/
-/[a]/ [[mu4e:m:/inria/archive or m:/gmail/archive or m:/univ/archive][Archive]] /........../ /[[mu4e:m:/inria/archive or m:/gmail/archive or m:/univ/archive|%5d][44978]]/
+/[i]/ [[mu:m:/inria/inbox or m:/gmail/inbox or m:/univ/inbox][Inbox]] /.............../ /[[mu:m:/inria/inbox or m:/gmail/inbox or m:/univ/inbox|%2d][ 4]]/
+/[f]/ [[mu:flag:flagged][Important]] /........../ /[[mu:flag:flagged|%3d][281]]/
+/[d]/ [[mu:m:/inria/drafts or m:/gmail/drafts or m:/univ/drafts][Drafts]] /.............../ /[[mu:m:/inria/drafts or m:/gmail/drafts or m:/univ/drafts|%1d][1]]/
+/[s]/ [[mu:m:/inria/sent or m:/gmail/sent or m:/univ/sent][Sent]] /............../ /[[mu:m:/inria/sent or m:/gmail/sent or m:/univ/sent|%4d][7186]]/
+/[a]/ [[mu:m:/inria/archive or m:/gmail/archive or m:/univ/archive][Archive]] /........../ /[[mu:m:/inria/archive or m:/gmail/archive or m:/univ/archive|%5d][44978]]/
 
 * Smart mailboxes
 
-/[t]/ [[mu4e:date:today..now][Today]] /............../ /[[mu4e:date:today..now|%3d][ 19]]/
-/[y]/ [[mu4e:date:2d..today and not date:today..now][Yesterday]] /........../ /[[mu4e:date:2d..today and not date:today..now|%3d][380]]/
-/[w]/ [[mu4e:date:1w..now][Last week]] /......... /[[mu4e:date:7d..now|%4d][1196]]/
-/[m]/ [[mu4e:date:4w..now][Last month]] /......../ /[[mu4e:date:4w..|%4d][3924]]/
+/[t]/ [[mu:date:today..now][Today]] /............../ /[[mu:date:today..now|%3d][ 19]]/
+/[y]/ [[mu:date:2d..today and not date:today..now][Yesterday]] /........../ /[[mu:date:2d..today and not date:today..now|%3d][380]]/
+/[w]/ [[mu:date:1w..now][Last week]] /......... /[[mu:date:7d..now|%4d][1196]]/
+/[m]/ [[mu:date:4w..now][Last month]] /......../ /[[mu:date:4w..|%4d][3924]]/
 
-[[mu4e:flag:attach][Attachments]] /........../ /[[mu4e:flag:attach|%5d][10040]]/
-[[mu4e:flag:encrypted][Encrypted]] /............./ /[[mu4e:flag:encrypted|%4d][ 888]]/
+[[mu:flag:attach][Attachments]] /........../ /[[mu:flag:attach|%5d][10040]]/
+[[mu:flag:encrypted][Encrypted]] /............./ /[[mu:flag:encrypted|%4d][ 888]]/
 
 ** Tags
 
-[[mu4e:tag:LINK][LINK]] /-/ [[mu4e:tag:PAPER][PAPER]] /-/ [[mu4e:tag:TODO][TODO]] /-/ [[mu4e:tag:CODE][CODE]]
-[[mu4e:tag:CV][CV]] /-/ [[mu4e:tag:ASPP][ASPP]] /-/ [[mu4e:tag:EDMI][EDMI]]
+[[mu:tag:LINK][LINK]] /-/ [[mu:tag:PAPER][PAPER]] /-/ [[mu:tag:TODO][TODO]] /-/ [[mu:tag:CODE][CODE]]
+[[mu:tag:CV][CV]] /-/ [[mu:tag:ASPP][ASPP]] /-/ [[mu:tag:EDMI][EDMI]]
  
 ** People
 
-[[mu4e:from:rms@gnu.org][Richard Stallman]]       /[[mu4e:from:rms@gnu.org|%3d][---]]/ 
-[[mu4e:from:djcb@djcbsoftware.nl][Dirk-Jan C. Binnema]] /[[mu4e:from:djcb@djcbsoftware.nl|%2d][    --]]/ 
+[[mu:from:rms@gnu.org][Richard Stallman]]       /[[mu:from:rms@gnu.org|%3d][---]]/ 
+[[mu:from:djcb@djcbsoftware.nl][Dirk-Jan C. Binnema]] /[[mu:from:djcb@djcbsoftware.nl|%2d][    --]]/ 
 
 ** Mailing lists
 
-[[mu4e:list:emacs-devel.gnu.org][Emacs development]] /.../ /[[mu4e:list:emacs-devel.gnu.org|%4d][3538]]/
-[[mu4e:list:mu-discuss.googlegroups.com][Mu4e discussions]] /...../ /[[mu4e:list:mu-discuss.googlegroups.com|%3d][277]]/
-[[mu4e:list:numpy-discussion.python.org][Numpy discussion]] /..../ /[[mu4e:list:numpy-discussion.python.org|%4d][1065]]/
+[[mu:list:emacs-devel.gnu.org][Emacs development]] /.../ /[[mu:list:emacs-devel.gnu.org|%4d][3538]]/
+[[mu:list:mu-discuss.googlegroups.com][Mu4e discussions]] /...../ /[[mu:list:mu-discuss.googlegroups.com|%3d][277]]/
+[[mu:list:numpy-discussion.python.org][Numpy discussion]] /..../ /[[mu:list:numpy-discussion.python.org|%4d][1065]]/
 
 ** Date
 
-[[mu4e:flag:attach][Year 2020]] /........../ /[[mu4e:date:20200101..20201231|%5d][29260]]/
-[[mu4e:date:20190101..20191231][Year 2019]] /........../ /[[mu4e:date:20190101..20191231|%5d][19845]]/
-[[mu4e:date:20180101..20181231][Year 2018]] /.........../ /[[mu4e:date:20180101..20181231|%4d][3038]]/
+[[mu:flag:attach][Year 2020]] /........../ /[[mu:date:20200101..20201231|%5d][29260]]/
+[[mu:date:20190101..20191231][Year 2019]] /........../ /[[mu:date:20190101..20191231|%5d][19845]]/
+[[mu:date:20180101..20181231][Year 2018]] /.........../ /[[mu:date:20180101..20181231|%4d][3038]]/
 
 * /Configuration/
 :PROPERTIES:


### PR DESCRIPTION
The present, the hard-coded link type "mu4e" will clash with that defined by 'org-mu4e'. Since users have presumably already authored dashboards using the "mu4e" link type, this commit doesn't change that; it instead makes the link type defined
by 'mu4e-dashboard' customizable with a default of "mu4e". This will allow existing dashboards to continue to work, while also
allowing user to change it if they so desire. Perhaps at a later date, say when this packge reaches 1.0, we can pick a new link type and standardize on that.

This commit will also address issue #6 by replacing the use of the deprecated 'org-add-link-type' with 'org-link-set-parameters').