### PR TITLE
Address issue #12 "Why not a minor mode?"

### DIFF
--- a/README.org
+++ b/README.org
@@ -78,10 +78,10 @@ RESULTS line.
 
 ** Usage
 
-   To activate the dashboard, type =mu4e-dashboard-acivate=. This will install
-   a =mu4e-dashboard-mode= minor mode with dedicated keybindngs.
-   
-   To edit the org file, you'll need to deactivate if first using
-   =mu4e-dashboard-deacivate=.
+To activate the dashboard, type =mu4e-dashboard-mode=. This will turn on
+=mu4e-dashboard-mode= minor mode and install any custom keybindings in
+the current buffer.
+
+To edit the org file, you'll need to turn off =mu4e-dashboard-mode=.
 
 


### PR DESCRIPTION
This commit re-implements `mu4e-dashboard` as a minor mode, removing the need for the variable `mu4e-dashboard--buffer` and allowing multiple dashboards to be active at the same time.

Instead of "activating" a dashboard, one just turns on the minor mode. This will install a *copy* of the local keymap, updated with
any keybindings defined in the current dashboard. In this way, multiple dashboards can be active simultaneously, each with their own local keymap.
