### PR TITLE
Added support for bookmarks

### DIFF
--- a/README.org
+++ b/README.org
@@ -38,7 +38,7 @@ number of results to be returned. When the link is clicked,
 #+end_src
 
 =format= can be used to specify that =query= results are to be counted in
-order to update the descritption using the given format:
+order to update the description using the given format:
 
 #+begin_src org
 [[mu:flag:unread|%3d][---]]
@@ -46,6 +46,38 @@ order to update the descritption using the given format:
 
 With the example above, when the link is cliked, the =---= part will be
 replaced by the number of unread mails.
+
+*** Using mu4e-bookmarks
+
+Queries can include references to mu4e-bookmarks. A bookmark is denoted with
+~bm:<bookmarkName>~
+ 
+~bookmarkName~ cannot contain spaces nor ]. A query can contain several bookmarks,
+but their expansion is not recursive.
+
+For example, assuming the following bookmark exists:
+
+#+begin_src emacs-lisp   :exports both
+(add-to-list 'mu4e-bookmarks
+     '(:name "Unread"
+           :query "flag:unread and not flag:trashed"
+           :key ?f)
+     t)
+#+end_src
+
+the dashboard query:
+
+#+begin_src emacs-lisp   :exports both
+mu:bm:Unread and date:7d..now
+#+end_src
+
+will be expanded to:
+
+#+begin_src emacs-lisp   :exports both
+mu:(flag:unread and not flag:trashed) and date:7d..now
+#+end_src
+
+Note that parenthesis are added around the bookmark to make sure the expansion is hygienic.
 
 *** Key bindings
 

--- a/mu4e-dashboard.el
+++ b/mu4e-dashboard.el
@@ -143,11 +143,9 @@ buffer is in the process of being updated asynchronously.")
       (progn
         (message (concat "bookmark not found: " bm))
         bm))))
-                 
+
 (defun mu4e-dashboard-expand-bookmarks-in-query (st)
   "if st contains a bookmark, replace it by its corresponding query, otherwise return st unchanged"
-;; we take advantage of the fact that many of the calls below return nil if the parameter is nil
-;; this avoids a long sequence of if statements
   (let ((bookmark-re "\\(bm:[^ ]+\\)")
          )
     (replace-regexp-in-string bookmark-re 'mu4e-dashboard-translate-bookmark-to-query  st)

--- a/mu4e-dashboard.el
+++ b/mu4e-dashboard.el
@@ -122,6 +122,36 @@ buffer is in the process of being updated asynchronously.")
     (message (concat mu4e-dashboard-file " does not exist"))
     ))
 
+(defun mu4e-dashboard-compare-bookmark-name (bookmark field-name st)
+  "compare st to the field field-name in the bookmark"
+  (equal (plist-get bookmark field-name) st))
+
+(defun mu4e-dashboard-find-bookmark (name)
+  "convert a mu4e bookmark to a query"
+  (if name
+      (cl-find-if (lambda (a) (mu4e-dashboard-compare-bookmark-name a :name name                                                                   ))
+                  mu4e-bookmarks)))
+
+(defun mu4e-dashboard-translate-bookmark-to-query (bm)
+  "translate a bm:<bookmarkName> into the mu4e query. Gets called by the regexp replacement"
+  (let ( ;; remove "bm:" from the begining of the name
+        (bookmark (mu4e-dashboard-find-bookmark (substring bm 3)))
+        )
+    (if bookmark
+        ;; put parenthesis around to make it hygenic
+          (concat "("(plist-get bookmark :query) ")")
+      (progn
+        (message (concat "bookmark not found: " bm))
+        bm))))
+                 
+(defun mu4e-dashboard-expand-bookmarks-in-query (st)
+  "if st contains a bookmark, replace it by its corresponding query, otherwise return st unchanged"
+;; we take advantage of the fact that many of the calls below return nil if the parameter is nil
+;; this avoids a long sequence of if statements
+  (let ((bookmark-re "\\(bm:[^ ]+\\)")
+         )
+    (replace-regexp-in-string bookmark-re 'mu4e-dashboard-translate-bookmark-to-query  st)
+    ))
 
 (defun mu4e-dashboard-follow-mu4e-link (path)
   "Process a mu4e link with path PATH.
@@ -134,13 +164,15 @@ updated with the QUERY count formatted using the provided
 format (for example \"%4d\")."
 
   (let* ((link    (org-element-context))
-         (query   (string-trim (nth 0 (split-string path "[]|]"))))
+         (queryname   (string-trim (nth 0 (split-string path "[]|]"))))
+         (query   (mu4e-dashboard-expand-bookmarks-in-query queryname))
          (fmt     (nth 1 (split-string path "[]|]")))
          (count   (nth 2 (split-string path "[]|]"))))
     (cond
      ;; Regular query without limit
      ((and (not fmt) (not count))
       (progn
+        (message query)
         (if (get-buffer-window "*mu4e-headers*" t)
             (switch-to-buffer"*mu4e-headers*"))
         (mu4e-headers-search query)))
@@ -169,7 +201,8 @@ format is too big for the current description, description is
 replaced with + signs."
 
   (let* ((path  (org-element-property :path link))
-         (query (string-trim (nth 0 (split-string path "|"))))
+         (queryname (string-trim (nth 0 (split-string path "|"))))
+         (query   (mu4e-dashboard-expand-bookmarks-in-query queryname))
          (fmt   (nth 1 (split-string path "|")))
          (beg   (org-element-property :contents-begin link))
          (end   (org-element-property :contents-end link))


### PR DESCRIPTION
Queries can now include references to bookmarks. A bookmark is denoted with

     bm:<bookmarkName>

bookmarkName cannot contain spaces nor ]

For example,

Assuming the following bookmark exists:

    (add-to-list 'mu4e-bookmarks
	     '(:name "Unread"
               :query "flag:unread and not flag:trashed"
               :key ?f)
	     t)

the dashboard query:

     mu:bm:Unread and date:7d..now

will be expanded as

    (flag:unread and not flag:trashed) and date:7d..now

note that parenthesis around the bookmark are added to make sure the expansion is hygienic.

A query can contain several bookmarks, but their expansion is not recursive.